### PR TITLE
FIX: Evaluating SiteSetting inside after_initialize causes issue with multisite 

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -39,11 +39,11 @@ after_initialize do
   module TopicViewLockdownExtension
     def check_and_raise_exceptions(skip_staff_action)
       super
-      raise ::CategoryLockdown::NoAccessLocked.new if CategoryLockdown.is_locked(@guardian, @topic)
+      raise ::CategoryLockdown::NoAccessLocked.new if SiteSetting.category_lockdown_enabled && CategoryLockdown.is_locked(@guardian, @topic)
     end
   end
 
-  ::TopicView.prepend TopicViewLockdownExtension if SiteSetting.category_lockdown_enabled
+  ::TopicView.prepend TopicViewLockdownExtension 
 
   TopicList.preloaded_custom_fields << "lockdown_enabled"
   TopicList.preloaded_custom_fields << "lockdown_allowed_groups"


### PR DESCRIPTION
As discussed here https://meta.discourse.org/t/advertise-activity-in-a-private-category-discourse-category-lockdown/70649/43?u=rgj

If a SiteSetting is evaluated in an `after_initialize` block, then there are two issues:
- multisite breaks because the setting is only evaluated in the context of the multisite master
- the setting is only evaluated upon Unicorn startup, i.e. a change of the setting requires a restart

The disadvantage of moving the SiteSetting away from there is that when a plugin breaks because of an incompatible function signature in the monkey patch, it still breaks when the plugin is disabled. However, since disabling it would require a restart anyway, it is a minor inconvenience compared to the two disadvantages mentioned above.