### PR TITLE
IMPROVE: add support for discourse-docs plugin

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-lockdown.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-lockdown.js.es6
@@ -56,6 +56,29 @@ function initializeLockdown(api) {
       return results;
     },
   });
+
+  api.modifyClassStatic("model:docs", {
+    list(params) {
+      return this._super(params).catch(error => {
+        let response = error.jqXHR.responseJSON;
+        const status = error.jqXHR.status;
+        if (status === 402) {
+          let redirectURL =
+            response.redirect_url ||
+            this.siteSettings.category_lockdown_redirect_url;
+
+          const external = redirectURL.startsWith("http");
+          if (external) {
+            // Use location.replace so that the user can go back in one click
+            document.location.replace(redirectURL);
+          } else {
+            // Handle the redirect inside ember
+            return DiscourseURL.handleURL(redirectURL, { replaceURL: true });
+          }
+        }
+      })
+    }
+  })
 }
 
 export default {

--- a/assets/javascripts/discourse/initializers/extend-for-lockdown.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-lockdown.js.es6
@@ -76,9 +76,9 @@ function initializeLockdown(api) {
             return DiscourseURL.handleURL(redirectURL, { replaceURL: true });
           }
         }
-      })
+      });
     }
-  })
+  });
 }
 
 export default {

--- a/plugin.rb
+++ b/plugin.rb
@@ -108,6 +108,7 @@ after_initialize do
         include_ember: true
       }
       topic_id = params["topic_id"] || params["id"]
+      topic_id ||= params["topic"] # if coming from discourse-docs plugin
       topic = Topic.find(topic_id.to_i) if topic_id
       response = {
         error: "Payment Required",


### PR DESCRIPTION
@angusmcleod 
I've adapted the following method with some modifications to support the docs plugin.
https://github.com/paviliondev/discourse-category-lockdown/blob/70c4473fcf3b4a0fd098243aa946ff3f8ae4e92f/assets/javascripts/discourse/initializers/extend-for-lockdown.js.es6#L10