### PR TITLE
Fix issue with Discourse Chat

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -11,6 +11,8 @@ register_asset 'stylesheets/lockdown.scss'
 require 'request_store'
 
 after_initialize do
+  register_category_custom_field_type('redirect_url', :string)
+
   Site.preloaded_category_custom_fields << 'redirect_url'
   add_to_serializer(:basic_category, :redirect_url, false) do
     object.custom_fields['redirect_url']


### PR DESCRIPTION
See https://thepavilion.io/t/lkllllllllll/5110

The Discourse Chat plugin crashes on "Browse Channels" when the Discourse Category Lockdown plugin is installed next to it.

The error is

```
HasCustomFields::NotPreloadedError (Attempted to access the non preloaded custom field 'redirect_url' on the 'Category' class. This is disallowed to prevent N+1 queries.)
app/models/concerns/has_custom_fields.rb:177:in `[]'
plugins/discourse-category-lockdown/plugin.rb:16:in `block (2 levels) in activate!'
```

When the line `register_category_custom_field_type('redirect_url', :string)` is added to `plugin.rb` then the error goes away. Apparently this is necessary nowadays (?)

## Logs

HasCustomFields::NotPreloadedError (Attempted to access the non preloaded custom field 'redirect_url' on the 'Category' class. This is disallowed to prevent N+1 queries.)
app/models/concerns/has_custom_fields.rb:177:in `[]'
(eval):33:in `_fast_attributes'
(eval):4:in `_fast_attributes'
app/controllers/application_controller.rb:484:in `serialize_data'
app/controllers/application_controller.rb:495:in `render_serialized'
app/controllers/application_controller.rb:387:in `block in with_resolved_locale'
app/controllers/application_controller.rb:387:in `with_resolved_locale'
lib/middleware/omniauth_bypass_middleware.rb:71:in `call'
lib/content_security_policy/middleware.rb:12:in `call'
lib/middleware/anonymous_cache.rb:356:in `call'
config/initializers/008-rack-cors.rb:25:in `call'
config/initializers/100-quiet_logger.rb:23:in `call'
config/initializers/100-silence_logger.rb:31:in `call'
lib/middleware/enforce_hostname.rb:23:in `call'
lib/middleware/request_tracker.rb:198:in `call'