### PR TITLE
Feature/allow authors access own topics

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,4 +6,4 @@ en:
     category_lockdown_allow_crawlers: Allow crawlers to access locked content if "everyone can see" is enabled.
     category_lockdown_crawler_noarchive: Add a 'noarchive' meta tag to disable search engine cache.
     category_lockdown_crawler_indicate_paywall: Add Schema.org metadata to indicate paywalled content.
-    allow_own_topics_in_locked_category: "Allow authors to view and post their own topics in locked categories"
+    allow_authors_in_locked_categories: "Allow authors to view and reply their own topics in locked categories"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,4 +6,4 @@ en:
     category_lockdown_allow_crawlers: Allow crawlers to access locked content if "everyone can see" is enabled.
     category_lockdown_crawler_noarchive: Add a 'noarchive' meta tag to disable search engine cache.
     category_lockdown_crawler_indicate_paywall: Add Schema.org metadata to indicate paywalled content.
-    allow_own_topics_in_locked_category: "Allow authors to view and post their own topics in locked categories?"
+    allow_own_topics_in_locked_category: "Allow authors to view and post their own topics in locked categories"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,4 +6,4 @@ en:
     category_lockdown_allow_crawlers: Allow crawlers to access locked content if "everyone can see" is enabled.
     category_lockdown_crawler_noarchive: Add a 'noarchive' meta tag to disable search engine cache.
     category_lockdown_crawler_indicate_paywall: Add Schema.org metadata to indicate paywalled content.
-    allow_authors_in_locked_categories: "Allow authors to view and reply their own topics in locked categories"
+    allow_authors_in_locked_categories: "Allow authors to view and reply to their own topics in locked categories."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,3 +6,4 @@ en:
     category_lockdown_allow_crawlers: Allow crawlers to access locked content if "everyone can see" is enabled.
     category_lockdown_crawler_noarchive: Add a 'noarchive' meta tag to disable search engine cache.
     category_lockdown_crawler_indicate_paywall: Add Schema.org metadata to indicate paywalled content.
+    allow_own_topics_in_locked_category: "Allow authors to view and post their own topics in locked categories?"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,9 +8,11 @@ plugins:
   category_lockdown_redirect_url:
     default: "/"
     client: true
-  category_lockdown_allow_crawlers: 
+  category_lockdown_allow_crawlers:
     default: false
   category_lockdown_crawler_noarchive:
     default: true
   category_lockdown_crawler_indicate_paywall:
     default: true
+  allow_own_topics_in_locked_category:
+    default: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,7 +8,7 @@ plugins:
   category_lockdown_redirect_url:
     default: "/"
     client: true
-  category_lockdown_allow_crawlers:
+  category_lockdown_allow_crawlers: 
     default: false
   category_lockdown_crawler_noarchive:
     default: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,5 +14,5 @@ plugins:
     default: true
   category_lockdown_crawler_indicate_paywall:
     default: true
-  allow_own_topics_in_locked_category:
+  allow_authors_in_locked_categories:
     default: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -43,7 +43,7 @@ after_initialize do
               'isAccessibleForFree' => 'False',
               'cssSelector' => 'body'
             },
-          ).gsub("</", "<\\/").html_safe,
+          ).gsub("</", "<\\/").html_safe, 
           '</script>',
         ].join("")  
       end
@@ -99,8 +99,8 @@ after_initialize do
     def check_and_raise_exceptions(skip_staff_action)
       super
       return if ::RequestStore.store[:is_crawler] && SiteSetting.category_lockdown_allow_crawlers
-        raise ::CategoryLockdown::NoAccessLocked.new if SiteSetting.category_lockdown_enabled && CategoryLockdown.is_locked(@guardian, @topic)
-            end
+      raise ::CategoryLockdown::NoAccessLocked.new if SiteSetting.category_lockdown_enabled && CategoryLockdown.is_locked(@guardian, @topic)
+    end
   end
 
   ::TopicView.prepend TopicViewLockdownExtension
@@ -139,7 +139,7 @@ after_initialize do
 
     def can_see_post?(post)
       return old_can_see_post?(post) unless SiteSetting.category_lockdown_enabled
-        
+
       return false if !old_can_see_post?(post)
       return false if ::CategoryLockdown.is_locked(self, post.topic)
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -32,20 +32,20 @@ after_initialize do
       inject = []
       if SiteSetting.category_lockdown_crawler_indicate_paywall
         inject.push [
-          '<script type="application/ld+json">', 
-          MultiJson.dump(
-            '@context' => 'http://schema.org',
-            '@type' => 'CreativeWork',
-            'name' => topic&.title,
-            'isAccessibleForFree' => 'False',
-            'hasPart' => {
-              '@type' => 'DiscussionForumPosting',
-              'isAccessibleForFree' => 'False',
-              'cssSelector' => 'body'
-            },
-          ).gsub("</", "<\\/").html_safe, 
-          '</script>',
-        ].join("")  
+                      '<script type="application/ld+json">',
+                      MultiJson.dump(
+                          '@context' => 'http://schema.org',
+                          '@type' => 'CreativeWork',
+                          'name' => topic&.title,
+                          'isAccessibleForFree' => 'False',
+                          'hasPart' => {
+                            '@type' => 'DiscussionForumPosting',
+                            'isAccessibleForFree' => 'False',
+                            'cssSelector' => 'body'
+                          },
+          ).gsub("</", "<\\/").html_safe,
+                      '</script>',
+                    ].join("")
       end
       if SiteSetting.category_lockdown_crawler_noarchive
         inject.push '<meta name="robots" content="noarchive">'
@@ -72,8 +72,8 @@ after_initialize do
     def self.is_locked(guardian, topic)
       return false if guardian.is_admin?
 
-      # Check if the feature is enabled and the user is the author of the topic
-      if SiteSetting.allow_own_topics_in_locked_category && guardian&.user&.id == topic&.user_id
+      if SiteSetting.allow_authors_in_locked_categories &&
+           guardian&.user&.id == topic&.user_id
         return false
       end
 
@@ -99,8 +99,8 @@ after_initialize do
     def check_and_raise_exceptions(skip_staff_action)
       super
       return if ::RequestStore.store[:is_crawler] && SiteSetting.category_lockdown_allow_crawlers
-      raise ::CategoryLockdown::NoAccessLocked.new if SiteSetting.category_lockdown_enabled && CategoryLockdown.is_locked(@guardian, @topic)
-    end
+        raise ::CategoryLockdown::NoAccessLocked.new if SiteSetting.category_lockdown_enabled && CategoryLockdown.is_locked(@guardian, @topic)
+            end
   end
 
   ::TopicView.prepend TopicViewLockdownExtension
@@ -139,7 +139,7 @@ after_initialize do
 
     def can_see_post?(post)
       return old_can_see_post?(post) unless SiteSetting.category_lockdown_enabled
-
+        
       return false if !old_can_see_post?(post)
       return false if ::CategoryLockdown.is_locked(self, post.topic)
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -32,20 +32,20 @@ after_initialize do
       inject = []
       if SiteSetting.category_lockdown_crawler_indicate_paywall
         inject.push [
-          '<script type="application/ld+json">',
+          '<script type="application/ld+json">', 
           MultiJson.dump(
-              '@context' => 'http://schema.org',
-              '@type' => 'CreativeWork',
-              'name' => topic&.title,
+            '@context' => 'http://schema.org',
+            '@type' => 'CreativeWork',
+            'name' => topic&.title,
+            'isAccessibleForFree' => 'False',
+            'hasPart' => {
+              '@type' => 'DiscussionForumPosting',
               'isAccessibleForFree' => 'False',
-              'hasPart' => {
-                '@type' => 'DiscussionForumPosting',
-                'isAccessibleForFree' => 'False',
-                'cssSelector' => 'body'
-              },
+              'cssSelector' => 'body'
+            },
           ).gsub("</", "<\\/").html_safe,
           '</script>',
-        ].join("")
+        ].join("")  
       end
       if SiteSetting.category_lockdown_crawler_noarchive
         inject.push '<meta name="robots" content="noarchive">'

--- a/plugin.rb
+++ b/plugin.rb
@@ -32,20 +32,20 @@ after_initialize do
       inject = []
       if SiteSetting.category_lockdown_crawler_indicate_paywall
         inject.push [
-                      '<script type="application/ld+json">',
-                      MultiJson.dump(
-                          '@context' => 'http://schema.org',
-                          '@type' => 'CreativeWork',
-                          'name' => topic&.title,
-                          'isAccessibleForFree' => 'False',
-                          'hasPart' => {
-                            '@type' => 'DiscussionForumPosting',
-                            'isAccessibleForFree' => 'False',
-                            'cssSelector' => 'body'
-                          },
+          '<script type="application/ld+json">',
+          MultiJson.dump(
+              '@context' => 'http://schema.org',
+              '@type' => 'CreativeWork',
+              'name' => topic&.title,
+              'isAccessibleForFree' => 'False',
+              'hasPart' => {
+                '@type' => 'DiscussionForumPosting',
+                'isAccessibleForFree' => 'False',
+                'cssSelector' => 'body'
+              },
           ).gsub("</", "<\\/").html_safe,
-                      '</script>',
-                    ].join("")
+          '</script>',
+        ].join("")
       end
       if SiteSetting.category_lockdown_crawler_noarchive
         inject.push '<meta name="robots" content="noarchive">'

--- a/plugin.rb
+++ b/plugin.rb
@@ -72,6 +72,11 @@ after_initialize do
     def self.is_locked(guardian, topic)
       return false if guardian.is_admin?
 
+      # Check if the feature is enabled and the user is the author of the topic
+      if SiteSetting.allow_own_topics_in_locked_category && guardian&.user&.id == topic&.user_id
+        return false
+      end
+
       locked_down = topic.category&.custom_fields&.[]("lockdown_enabled") == "true"
       return false if !locked_down
 

--- a/spec/category_lockdown_spec.rb
+++ b/spec/category_lockdown_spec.rb
@@ -68,10 +68,8 @@ RSpec.describe 'CategoryLockdown', type: :request do
       get "/t/#{topic.slug}/#{topic.id}"
       expect(response.code).to eq("200")
     end
-    context "with allow_own_topics_in_locked_category enabled" do
-      before do
-        SiteSetting.allow_own_topics_in_locked_category = true
-      end
+    context "with allow_authors_in_locked_categories enabled" do
+      before { SiteSetting.allow_authors_in_locked_categories = true }
 
       it 'allows authors access to their own topics' do
         sign_in(author) # user is the author of the topic

--- a/spec/category_lockdown_spec.rb
+++ b/spec/category_lockdown_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'CategoryLockdown', type: :request do
   end
 
   let(:category) { Fabricate(:category) }
-  let(:topic) { Fabricate(:topic, category: category, user: user) }
+  let(:author) { Fabricate(:user) }
+  let(:topic) { Fabricate(:topic, category: category, user: author) }
   let(:allowed_group) { Fabricate(:group) }
   let(:allowed_user) { Fabricate(:user, groups: [allowed_group]) }
   let(:user) { Fabricate(:user) }
@@ -50,6 +51,11 @@ RSpec.describe 'CategoryLockdown', type: :request do
       get "/t/#{topic.slug}/#{topic.id}"
       expect(response.code).to eq("301")
     end
+    it "doesn't allow author access" do
+      sign_in(author)
+      get "/t/#{topic.slug}/#{topic.id}"
+      expect(response.code).to eq('301')
+    end
 
     it "allows admins access" do
       sign_in(admin)
@@ -67,8 +73,8 @@ RSpec.describe 'CategoryLockdown', type: :request do
         SiteSetting.allow_own_topics_in_locked_category = true
       end
 
-      it "allows authors access to their own topics" do
-        sign_in(user) # user is the author of the topic
+      it 'allows authors access to their own topics' do
+        sign_in(author) # user is the author of the topic
         get "/t/#{topic.slug}/#{topic.id}"
         expect(response.code).to eq("200")
       end


### PR DESCRIPTION
### Summary
This PR introduces a new feature controlled by the setting `allow_authors_in_locked_categories`, which allows authors to read and write in their own topics within locked categories.

### Changes
- Added new setting `allow_authors_in_locked_categories` with a default value of `false`.
- Implemented conditional logic in the relevant controller to bypass category restrictions for authors when the setting is enabled.
- Updated automated tests to cover this new feature.

### Rationale
In locked categories, only users in permitted groups can access topics. This feature lets topic authors access their own topics in these categories, giving admins more flexibility.

### Testing
- Manual tests were conducted to confirm that authors can read/write in their own topics in locked categories when the setting is enabled.
- Automated tests were added to ensure the feature works as expected.

### Backward Compatibility
The feature is disabled by default, ensuring that existing setups will not be affected unless the setting is explicitly turned on.

Please review and provide your feedback.
