### PR TITLE
Some modernizations

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-lockdown.js
+++ b/assets/javascripts/discourse/initializers/extend-for-lockdown.js
@@ -40,32 +40,34 @@ function initializeLockdown(api) {
     }
   );
 
-  // Warning: "route:docs-index" may not be found if the 'discourse-docs' plugin is not installed. This is expected and harmless.
-  api.modifyClass("route:docs-index", {
-    pluginId: PLUGIN_ID,
-    model(params, transition) {
-      return this._super(params).catch((error) => {
-        let response = error.jqXHR.responseJSON;
-        const status = error.jqXHR.status;
-        if (status === 402) {
-          // abort the transition to prevent momentary error
-          // from being displayed
-          transition.abort();
-          let redirectURL =
-            response.redirect_url ||
-            this.siteSettings.category_lockdown_redirect_url;
+  if (api.container.factoryFor("route:docs-index")) {
+    api.modifyClass("route:docs-index", {
+      pluginId: PLUGIN_ID,
+      model(params, transition) {
+        return this._super(params).catch((error) => {
+          let response = error.jqXHR.responseJSON;
+          const status = error.jqXHR.status;
+          if (status === 402) {
+            // abort the transition to prevent momentary error
+            // from being displayed
+            transition.abort();
+            let redirectURL =
+              response.redirect_url ||
+              this.siteSettings.category_lockdown_redirect_url;
 
-          const external = redirectURL.startsWith("http");
-          if (external) {
-            document.location.href = redirectURL;
-          } else {
-            // Handle the redirect inside ember
-            return DiscourseURL.handleURL(redirectURL, { replaceURL: true });
+            const external = redirectURL.startsWith("http");
+            if (external) {
+              document.location.href = redirectURL;
+            } else {
+              // Handle the redirect inside ember
+              return DiscourseURL.handleURL(redirectURL, { replaceURL: true });
+            }
           }
-        }
-      });
-    },
-  });
+        });
+      },
+    });
+  }
+
 }
 
 export default {

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-category-lockdown
 # about: Set all topics in a category to redirect, unless part of a specified group
-# version: 1.2.0
+# version: 1.2.1
 # authors: Pavilion
 # meta_topic_id: 70649
 # url: https://github.com/paviliondev/discourse-category-lockdown


### PR DESCRIPTION
- `modifyClass("model:post-stream")` failed because the `errorLoading` function changed its inner workings
  Replaced with a modern `registerBehaviorTransformer`

- fenced the `api.modifyClass("route:docs-index")` call to suppress the warning when the docs plugin is not installed.